### PR TITLE
Fix `maid.imports does not exist` bug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.nix]
+indent_size = 2

--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -17,16 +17,17 @@ let
   utils = import (pkgs.path + /nixos/lib/utils.nix);
 
   maidModule =
-    { config, ... }:
-    {
-      imports = (import ../maid/all-modules.nix);
-      _module.args = {
-        inherit pkgs;
-        # FIXME: If we pass-through nixos' systemdUtils, we get dbus.service in config.build.units
-        # inherit (utils) systemdUtils;
-
-        systemdUtils = (utils { inherit config pkgs lib; }).systemdUtils;
-      };
+    types.submoduleWith {
+      modules = lib.singleton
+        ( { config, ... }: {
+          imports = import ../maid/all-modules.nix;
+          config._module.args = {
+            inherit pkgs;
+            # FIXME: If we pass-through nixos' systemdUtils, we get dbus.service in config.build.units
+            # inherit (utils) systemdUtils;
+            systemdUtils = (utils { inherit config pkgs lib; }).systemdUtils;
+          };
+        } );
     };
 
   userSubmodule =
@@ -35,7 +36,7 @@ let
       options = {
         maid = mkOption {
           description = "Nix-maid configuration";
-          type = types.nullOr (types.submodule maidModule);
+          type = types.nullOr maidModule;
           default = null;
         };
       };


### PR DESCRIPTION
Closes https://github.com/viperML/nix-maid/issues/18

First of all, thanks for creating and maintaining nix-maid, it's a breath of fresh air comparing to home-manager.

I totally don't understand why `types.submodule` does not work but `types.submoduleWith` does, but it seems to solve the problem (it's stolen from home-manager though!). And I have no idea whether it will break other people existing config.

I also add a .editorconfig because I use 4 spaces to indent nix, but that's probably not the style of your project.