### PR TITLE
Set module class to "maid"

### DIFF
--- a/src/maid/default.nix
+++ b/src/maid/default.nix
@@ -9,6 +9,7 @@ in
   eval =
     extraModules:
     lib.evalModules {
+      class = "maid";
       modules =
         [
           (

--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -17,6 +17,7 @@ let
   utils = import (pkgs.path + /nixos/lib/utils.nix);
 
   maidModule = types.submoduleWith {
+    class = "maid";
     modules = lib.singleton (
       { config, ... }:
       {


### PR DESCRIPTION
See the documentation of `class` here: https://nixos.org/manual/nixpkgs/stable/index.html#module-system-lib-evalModules-param-class

Basically, this allows us to error clearly if we import any module with `_class` different from ours. (Modules with `_class` not set will still work though)