### PR TITLE
Declarative kconfig (kde/plasma configuration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /.direnv
 __pycache__
 *.qcow2
+.mypy_cache
+.cache
+build
+compile_commands.json

--- a/kconfig-declarative/.clang-format
+++ b/kconfig-declarative/.clang-format
@@ -1,0 +1,10 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+AccessModifierOffset: -2
+ColumnLimit: 80
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: BlockIndent

--- a/kconfig-declarative/.envrc
+++ b/kconfig-declarative/.envrc
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+use nix
+
+export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+export CMAKE_BUILD_TYPE=Debug
+export MAKEFLAGS=-j$(nproc)
+
+ln -sfT build/compile_commands.json compile_commands.json

--- a/kconfig-declarative/.vscode/launch.json
+++ b/kconfig-declarative/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb-dap",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceRoot}/build/kconfig-declarative",
+            "args": [
+                "${workspaceRoot}/manifest.json"
+            ],
+            "env": [],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "CMake: build"
+        }
+    ]
+}

--- a/kconfig-declarative/.vscode/tasks.json
+++ b/kconfig-declarative/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "CMake: build",
+			"command": "cmake --build ${workspaceFolder}/build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+		}
+	]
+}

--- a/kconfig-declarative/CMakeLists.txt
+++ b/kconfig-declarative/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(kconfig-declarative LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+set(main kconfig-declarative)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core)
+
+qt_standard_project_setup()
+
+qt_add_executable(${main}
+    src/main.cpp
+    src/load.cpp
+)
+
+target_link_libraries(${main} PRIVATE Qt6::Core)
+
+find_package(KF6Config REQUIRED)
+target_link_libraries(${main} PRIVATE KF6::ConfigCore)
+
+find_package(nlohmann_json REQUIRED)
+target_link_libraries(${main} PRIVATE nlohmann_json::nlohmann_json)
+
+find_package(CLI11 CONFIG REQUIRED)
+target_link_libraries(${main} PRIVATE CLI11::CLI11)
+
+target_compile_options(${main} PRIVATE -Werror -Wpedantic)
+
+target_include_directories(${main} PRIVATE src)
+
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  target_compile_options(
+    ${main}
+    PRIVATE -O0 -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer
+  )
+  target_link_options(${main}
+    PRIVATE -fsanitize=undefined -fsanitize=address
+  )
+endif()
+
+install(TARGETS ${main}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/kconfig-declarative/manifest.json
+++ b/kconfig-declarative/manifest.json
@@ -1,0 +1,14 @@
+{
+  "files": {
+    "kwinrc": {
+      "Desktops": {
+        "Number": 4
+      }
+    },
+		"baloofilerc": {
+			"Basic Settings": {
+				"Indexing-Enabled": false
+			}
+		}
+  }
+}

--- a/kconfig-declarative/package.nix
+++ b/kconfig-declarative/package.nix
@@ -1,0 +1,25 @@
+{
+  stdenv,
+  lib,
+  nix-gitignore,
+  cmake,
+  qt6,
+  kdePackages,
+  nlohmann_json,
+  cli11,
+}:
+stdenv.mkDerivation {
+  name = "kconfig-declarative";
+  src = nix-gitignore.gitignoreSource [ ../.gitignore ] (lib.cleanSource ./.);
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsNoGuiHook
+  ];
+  buildInputs = [
+    qt6.qtbase
+    kdePackages.kconfig
+    nlohmann_json
+    cli11
+  ];
+  meta.mainProgram = "kconfig-declarative";
+}

--- a/kconfig-declarative/shell.nix
+++ b/kconfig-declarative/shell.nix
@@ -1,0 +1,17 @@
+with import <nixpkgs> { };
+mkShell.override
+  {
+    stdenv = pkgs.clangStdenv;
+  }
+  {
+    packages = [
+      cmake
+      qt6.qtbase
+      kdePackages.kconfig
+      clang-tools
+      nlohmann_json
+      cli11
+      lldb
+    ];
+    hardeningDisable = [ "all" ];
+  }

--- a/kconfig-declarative/src/load.cpp
+++ b/kconfig-declarative/src/load.cpp
@@ -1,0 +1,112 @@
+#include "load.hpp"
+
+#include <KConfigGroup>
+#include <KSharedConfig>
+#include <map>
+#include <optional>
+#include <print>
+#include <string>
+#include <vector>
+
+using nlohmann::json;
+using std::optional;
+using std::println;
+using std::string;
+using std::vector;
+
+namespace ns {
+struct manifest {
+    std::map<std::string, json::object_t> files;
+};
+void from_json(const json& j, manifest& m) { j.at("files").get_to(m.files); }
+}  // namespace ns
+
+bool processJson(
+    KSharedConfig::Ptr kconfig,
+    optional<vector<string>> stack,
+    const json::object_t& obj
+) {
+    bool tainted = false;
+
+    for (auto [key, _value] : obj) {
+        if (_value.is_object()) {
+            // Recurse
+            auto newStack = stack.value_or(vector<string>{});
+            newStack.push_back(key);
+            processJson(kconfig, newStack, _value);
+        } else {
+            KConfigGroup group(kconfig, "");
+            if (stack) {
+                for (const auto& groupName : stack.value()) {
+                    group =
+                        KConfigGroup(&group, QString::fromStdString(groupName));
+                    print("{}/", groupName);
+                }
+            }
+
+            println("{} -> {}", key, _value.dump());
+
+            auto qKey = QString::fromStdString(key);
+
+            if (_value.is_string()) {
+                auto value = _value.get<string>();
+                QString qValue = QString::fromStdString(value);
+
+                QString prevValue = group.readEntry(qKey, QString());
+
+                group.writeEntry(qKey, qValue);
+
+                if (prevValue == qValue) {
+                    tainted = true;
+                }
+            } else if (_value.is_boolean()) {
+                auto value = _value.get<bool>();
+
+                bool prevValue = group.readEntry(qKey, false);
+
+                group.writeEntry(qKey, value);
+
+                if (prevValue == value) {
+                    tainted = true;
+                }
+            } else if (_value.is_number_integer()) {
+                auto value = _value.get<int>();
+
+                int prevValue = group.readEntry(qKey, 0);
+
+                group.writeEntry(qKey, value);
+
+                if (prevValue == value) {
+                    tainted = true;
+                }
+            } else {
+                println("Unknown type!");
+            }
+        }
+    }
+
+    return tainted;
+}
+
+void load(const json& manifest) {
+    auto m = manifest.get<ns::manifest>();
+
+    for (auto& [filename, fileConfig] : m.files) {
+        println("[{}]", filename);
+
+        KSharedConfig::Ptr kconfig =
+            KSharedConfig::openConfig(QString::fromStdString(filename));
+
+        bool tainted = processJson(kconfig, std::nullopt, fileConfig);
+
+        kconfig->sync();
+        println("  Tainted: {}", tainted);
+        println();
+        if (tainted) {
+            if (filename == "kwinrc") {
+                println("    Triggering kwin restart");
+                println("qdbus org.kde.KWin /KWin org.kde.KWin.restart");
+            }
+        }
+    }
+}

--- a/kconfig-declarative/src/load.hpp
+++ b/kconfig-declarative/src/load.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+
+void load(const json& manifest);

--- a/kconfig-declarative/src/main.cpp
+++ b/kconfig-declarative/src/main.cpp
@@ -1,0 +1,52 @@
+#include <CLI/CLI.hpp>
+#include <QCoreApplication>
+#include <print>
+
+#include "load.hpp"
+
+using nlohmann::json;
+using std::println;
+using std::filesystem::path;
+
+int applyCommand(std::string manifestPath) {
+    std::println("Manifest: {}", manifestPath);
+
+    path p(manifestPath);
+
+    // Check if exists
+    if (!std::filesystem::exists(p)) {
+        println("Manifest {} doesn't exit.", p.string());
+        return EXIT_FAILURE;
+    }
+
+    std::ifstream ifs(manifestPath);
+
+    json j = json::parse(ifs);
+
+    load(j);
+
+    return EXIT_SUCCESS;
+}
+
+int watchCommand() {
+    std::println("Watch command not yet implemented.");
+    return EXIT_SUCCESS;
+}
+
+int main(int argc, char** argv) {
+    CLI::App app{"App description"};
+    argv = app.ensure_utf8(argv);
+
+    auto watch_app = app.add_subcommand("watch", "Watch for changes");
+    auto apply_app = app.add_subcommand("apply", "Apply a manifest");
+    app.require_subcommand();
+
+    watch_app->callback([]() { watchCommand(); });
+
+    std::string manifestPath;
+    apply_app->add_option("manifest", manifestPath)->required();
+
+    apply_app->callback([&manifestPath]() { applyCommand(manifestPath); });
+
+    CLI11_PARSE(app, argc, argv);
+}

--- a/src/maid/modules/kconfig.nix
+++ b/src/maid/modules/kconfig.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib) types;
+  format = pkgs.formats.json { };
+  inherit (lib) mkOption literalExpression;
+in
+{
+
+  options = {
+    kconfig = mkOption {
+      description = ''
+        Declarative configuration for KDE Plasma.
+
+        Some changes may need a restart of the affected application or the whole system.
+      '';
+      example = literalExpression ''
+        settings = {
+          kwinrc = {
+            Desktops.Number = 4;
+          };
+        };
+      '';
+      type = types.submodule {
+        options = {
+          settings = lib.mkOption {
+            type = types.attrsOf format.type;
+            description = "Configuration for each KDE Plasma file. The value can be anything serializable to json";
+            example = literalExpression ''
+              kwinrc = {
+                Desktops.Number = 4;
+              };
+            '';
+          };
+
+          manifest = lib.mkOption {
+            visible = false;
+            readOnly = true;
+            default = format.generate "kconfig-manifest.json" {
+              files = config.kconfig.settings;
+            };
+          };
+
+          package = lib.mkOption {
+            type = types.package;
+            default = pkgs.callPackage ../../../kconfig-declarative/package.nix { };
+            visible = false;
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf ((builtins.attrNames config.kconfig.settings) != [ ]) {
+    systemd.services.maid-kconfig = {
+      wantedBy = [ config.maid.systemdTarget ];
+      restartIfChanged = true;
+      restartTriggers = [ config.kconfig.manifest ];
+      serviceConfig = {
+        RemainAfterExit = true;
+        Type = "oneshot";
+        ExecStart = "${lib.getExe config.kconfig.package} apply ${config.kconfig.manifest}";
+      };
+    };
+  };
+}

--- a/test/default.nix
+++ b/test/default.nix
@@ -39,4 +39,10 @@ in
   dconf.settings = {
     "/org/gnome/desktop/interface/color-scheme" = "prefer-dark";
   };
+
+  kconfig.settings = {
+    kwinrc = {
+      Desktops.Number = 4;
+    };
+  };
 }

--- a/test/nixos.nix
+++ b/test/nixos.nix
@@ -35,6 +35,11 @@ pkgs.nixos {
         wantedBy = [ "default.target" ];
 
       };
+      kconfig.settings = {
+        kwinrc = {
+          Desktops.Number = 4;
+        };
+      };
     };
     extraGroups = [ "wheel" ];
   };


### PR DESCRIPTION
This PR adds support for configuring plasma, by loading values into kconfig. Similar to https://github.com/nix-community/plasma-manager, but they parse the kconfig files which is horrible. Instead we will use the c++ kde library to load the data.