### PR TITLE
Use loginctl for activation discovery

### DIFF
--- a/src/maid/modules/core.nix
+++ b/src/maid/modules/core.nix
@@ -432,14 +432,15 @@ in
       };
 
       testScript = ''
+        machine.succeed("loginctl enable-linger alice")
+        machine.succeed("loginctl list-users | grep alice")
         machine.wait_for_unit("user@1000.service")
         machine.wait_for_unit("maid-system-activation.service")
         machine.wait_for_unit("maid-activation.service", "alice")
         machine.succeed("cat /home/alice/foo")
 
         machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration test")
-        machine.wait_for_unit("maid-system-activation.service")
-        machine.wait_for_unit("maid-activation.service", "alice")
+        machine.sleep(10)
         machine.fail("stat /home/alice/foo")
       '';
     };

--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -96,6 +96,8 @@ in
       )
     );
 
+    services.dbus.implementation = "broker";
+
     systemd.services.maid-system-activation = {
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ config.system.build.all-maid ];
@@ -106,19 +108,25 @@ in
       };
       # enableStrictShellChecks = true;
       description = "System to user activation, workaround for https://github.com/NixOS/nixpkgs/issues/246611";
+      path = [ pkgs.jq ];
       script = ''
-        for dir in ${config.system.build.all-maid}/*; do
-          _basename="$(basename "$dir")"
-          USER="''${_basename#nix-maid-}"
-          XDG_RUNTIME_DIR="/run/user/$(id -u "$USER")"
-          echo "Checking $USER..."
-          if [[ -f "$XDG_RUNTIME_DIR/maid-started" ]]; then
-            if systemctl --user --machine "$USER@.host" is-active maid-activation.service; then
-              echo "Restarting for $USER"
-              systemctl --user --machine "$USER@.host" restart maid-activation.service || :
+        set +e
+        exit_status=0
+
+        while IFS= read -r line; do
+          state="$(echo "$line" | jq -r .state)"
+          user="$(echo "$line" | jq -r .user)"
+          if [[ "$state" = "active" ]]; then
+            echo ":: Restarting nix-maid for user $user"
+            systemctl try-restart --user --machine "$user@" maid-activation.service
+            _e=$?
+            if [[ $_e != 0 ]]; then
+              exit_status=$_e
             fi
           fi
-        done
+        done < <(loginctl list-users --json=short | jq -rc '.[]')
+
+        exit "$exit_status"
       '';
     };
 

--- a/test/nixos.nix
+++ b/test/nixos.nix
@@ -14,6 +14,14 @@
     }
   ];
 
+  specialisation.new-generation.configuration = {
+    maid.sharedModules = [
+      {
+        file.home.spec.source = "/dev/null";
+      }
+    ];
+  };
+
   users.mutableUsers = false;
   security.sudo.wheelNeedsPassword = false;
 
@@ -54,7 +62,11 @@
     isNormalUser = true;
   };
 
+  users.users.root.password = "root";
+
   virtualisation.vmVariant = {
     virtualisation.graphics = false;
   };
+
+  security.polkit.enable = true;
 }


### PR DESCRIPTION
The maid-systemd-activation.service is responsible of restarting nix-maid upon a nixos-rebuild. Currently it doesn't discover users that are configured through maid.sharedModulesForAllUsers, this should fix this.