### PR TITLE
Use buildEnv instead of symlinkJoin for better symlink handling

### DIFF
--- a/src/maid/modules/core.nix
+++ b/src/maid/modules/core.nix
@@ -361,7 +361,7 @@ in
       upstreamWants = [ ];
     };
 
-    build.bundle = pkgs.symlinkJoin {
+    build.bundle = pkgs.buildEnv {
       name = "nix-maid";
       paths = config.packages ++ [
         # config.build.staticTmpfiles
@@ -441,6 +441,43 @@ in
         machine.wait_for_unit("maid-system-activation.service")
         machine.wait_for_unit("maid-activation.service", "alice")
         machine.fail("stat /home/alice/foo")
+      '';
+    };
+
+    tests.buildenv-merging = {
+      nodes.machine =
+        let
+          # Package with a real applications directory
+          pkg-real-dir = pkgs.runCommand "pkg-real-dir" { } ''
+            mkdir -p $out/share/applications
+            echo "real" > $out/share/applications/real.desktop
+          '';
+
+          # Package with a symlinked applications directory (mimics emacs.pkgs.withPackages)
+          pkg-symlinked-dir = pkgs.runCommand "pkg-symlinked-dir" { } ''
+            mkdir -p $out/inner
+            mkdir -p $out/share
+            echo "symlinked" > $out/inner/symlinked.desktop
+            ln -s $out/inner $out/share/applications
+          '';
+        in
+        {
+          users.users.alice.maid = {
+            packages = [
+              pkg-real-dir
+              pkg-symlinked-dir
+            ];
+          };
+        };
+
+      testScript = ''
+        machine.wait_for_unit("user@1000.service")
+        machine.wait_for_unit("maid-activation.service", "alice")
+
+        # Verify both desktop files exist in alice's NixOS user profile
+        # This tests that buildEnv can merge real and symlinked directories
+        machine.succeed("test -f /etc/profiles/per-user/alice/share/applications/real.desktop")
+        machine.succeed("test -f /etc/profiles/per-user/alice/share/applications/symlinked.desktop")
       '';
     };
   };


### PR DESCRIPTION
When using packages with directory-level symlinks in nix-maid environments, .desktop files and other resources would not appear in application launchers.

Specifically, emacs.pkgs.withPackages creates a wrapper derivation where [share/applications is a *symlink* to the base emacs package's share/applications directory](https://github.com/NixOS/nixpkgs/blob/b0fe1026a1974ef2ea64294c840a3fa6b81e3a44/pkgs/applications/editors/emacs/build-support/wrapper.nix#L258), rather than a real directory containing symlinks to individual files.

When nix-maid used symlinkJoin to merge multiple packages where:
- Package A has share/applications as a real directory
- Package B (e.g., emacs wrapper) has share/applications as a symlink to another directory

... then, they would fail to merge, outputting "applications: File exists" and skipping the symlinked directory entirely.

This is documented in nixpkgs' symlinkJoin documentation:

  "BEWARE: it may not 'work right' when the passed paths contain symlinks to directories."

Meanwhile, buildEnv does more sophisticated merging, which gracefully handles these directory-level symlinks.

This commit introduces a breaking change:

* before: if there are conflicting paths, it will silently pick one, and discard the other.
* after: if there are conflicting paths, it will abort.

This is probably a positive change, but just FYI.