### PR TITLE
FIX: ShellCheck Warning SC2163

### DIFF
--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -136,7 +136,7 @@ in
         while IFS= read -r line; do
           for var in DBUS_SESSION_BUS_ADDRESS DISPLAY WAYLAND_DISPLAY XAUTHORITY XDG_RUNTIME_DIR; do
             if [[ "$line" == "$var="* ]]; then
-              export "$line"
+              export "''${line?}"
             fi
           done
         done < <(systemctl --user show-environment 2>/dev/null)


### PR DESCRIPTION
We need to fix the warning so that Nix Maid works with the `systemd.enableStrictShellChecks` NixOS option set to `true`.

ShellCheck Warning Page:
https://www.shellcheck.net/wiki/SC2163