### PR TITLE
FIX: Remove Absolute Path Literal

### DIFF
--- a/src/nixos/default.nix
+++ b/src/nixos/default.nix
@@ -12,7 +12,7 @@ let
     filterAttrs
     ;
 
-  utils = import (pkgs.path + /nixos/lib/utils.nix);
+  utils = import (pkgs.path + "/nixos/lib/utils.nix");
 
   maidModule = types.submoduleWith {
     class = "maid";


### PR DESCRIPTION
Absolute path literals are not portable.
Nix complains about the changed line if the option `lint-absolute-path-literals` is set to `warn`.

`lint-absolute-path-literals` Option Documentation:
https://nix.dev/manual/nix/2.34/command-ref/conf-file.html#conf-lint-absolute-path-literals